### PR TITLE
Add tempo emulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ When Live MIDI mode is enabled, normal song playback is disabled. Instead, the s
     * **2**: Auto pan
   * **24**: Fine tune
   * **26**: Modulation delay (ticks before mod kicks in)
+  * **29**: Emulate tempo change (defaults to 150bpm). The value must be half the BPM (e.g., use value `60` for 120bpm). This is only used to determine tick timing (like for modulation delay).
   * **33**: Polyphony note priority
   * **123**: All notes off
 * Issuing extended commands like psuedo-echo aren't supported yet in Live MIDI mode.
@@ -59,6 +60,7 @@ When Live MIDI mode is enabled, normal song playback is disabled. Instead, the s
 - T: Toggle whether the song should be output to a file (see R and E)
 - G: Drag the song through the playlist for ordering
 - I: Force song restart
+  - In Live MIDI mode this will simply turn off all notes without resetting controllers.
 - O: Song play/pause
 - P: Force song stop
 - +=: Double the playback speed

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ agbplay <ROM.gba> [song table position] [MIDI port number]
 To list MIDI port numbers that can be used as the MIDI port number value, use `agbplay --help`.
 
 ```
-There are 9 MIDI input sources available.
+There are 3 MIDI input sources available.
   Input Port #1: IAC Driver Bus 1
   Input Port #2: IAC Driver Bus 2
   Input Port #3: CASIO USB-MIDI
@@ -32,25 +32,25 @@ When Live MIDI mode is enabled, normal song playback is disabled. Instead, the s
 
 #### MIDI reference
 
-* MIDI channel corresponds to track number (1-16).
-* Program change does as expected, however note that no sound will be produced until a program change is issued.
-* Pitch bend works as expected, however the resolution is limited to the upper 7-bits (-64 to 63). Bend range can be set with the BENDR control.
-* Control change
-  * **1**: Modulation depth (see settings below)
-  * **7**: Volume
-  * **10**: Pan 
-  * **20**: Pitch bend range
-  * **21**: Modulation speed
-  * **22**: Modulation type
-    * **0**: Vibrato
-    * **1**: Tremolo
-    * **2**: Auto pan
-  * **24**: Fine tune
-  * **26**: Modulation delay (ticks before mod kicks in)
-  * **29**: Emulate tempo change (defaults to 150bpm). The value must be half the BPM (e.g., use value `60` for 120bpm). This is only used to determine tick timing (like for modulation delay).
-  * **33**: Polyphony note priority
-  * **123**: All notes off
-* Issuing extended commands like psuedo-echo aren't supported yet in Live MIDI mode.
+- MIDI channel corresponds to track number (1-16).
+- Program change does as expected, however note that no sound will be produced until a program change is issued.
+- Pitch bend works as expected, however the resolution is limited to the upper 7-bits (-64 to 63). Bend range can be set with the BENDR control.
+- Control change
+  - **1**: Modulation depth (see settings below)
+  - **7**: Volume
+  - **10**: Pan 
+  - **20**: Pitch bend range
+  - **21**: Modulation speed
+  - **22**: Modulation type
+    - **0**: Vibrato
+    - **1**: Tremolo
+    - **2**: Auto pan
+  - **24**: Fine tune
+  - **26**: Modulation delay (ticks before mod kicks in)
+  - **29**: Emulate tempo change (defaults to 150bpm). The value must be half the BPM (e.g., use value `60` for 120bpm). This is only used to determine tick timing (like for modulation delay).
+  - **33**: Polyphony note priority
+  - **123**: All notes off
+- Issuing extended commands like psuedo-echo aren't supported yet in Live MIDI mode.
 
 ### Controls
 - Arrow Keys or HJKL: Navigate through the program

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ When Live MIDI mode is enabled, normal song playback is disabled. Instead, the s
     - **2**: Auto pan
   - **24**: Fine tune
   - **26**: Modulation delay (ticks before mod kicks in)
-  - **29**: Emulate tempo change (defaults to 150bpm). The value must be half the BPM (e.g., use value `60` for 120bpm). This is only used to determine tick timing (like for modulation delay).
+  - **29**: Emulate tempo change (defaults to 150bpm). The value must be half the BPM (e.g., use value `60` for 120bpm). This is only used to determine tick timing, e.g., for modulation delay. (affects all channels)
   - **33**: Polyphony note priority
-  - **123**: All notes off
+  - **123**: All notes off (affects all channels)
 - Issuing extended commands like psuedo-echo aren't supported yet in Live MIDI mode.
 
 ### Controls

--- a/src/OS.cpp
+++ b/src/OS.cpp
@@ -98,30 +98,3 @@ const std::filesystem::path OS::GetGlobalConfigDirectory()
 // Unsupported OS
 #error "Apparently your OS is neither Windows nor appears to be a UNIX variant (no unistd.h). You will have to add support for your OS in src/OS.cpp :/"
 #endif
-
-#ifdef __APPLE__
-// #include <libproc.h>
-#include <sys/sysctl.h>
-#include <unistd.h>
-
-// http://www.objectpark.net/en/parentpid.html
-
-#define OPProcessValueUnknown UINT_MAX
-
-// static int OPParentIDForProcessID(int pid)
-// /*" Returns the parent process id
-//      for the given process id (pid). "*/
-// {
-//     struct kinfo_proc info;
-//     size_t length = sizeof(struct kinfo_proc);
-//     int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, pid };
-//     if (sysctl(mib, 4, &info, &length, NULL, 0) < 0)
-//         return OPProcessValueUnknown;
-//     if (length == 0)
-//         return OPProcessValueUnknown;
-//     return info.kp_eproc.e_ppid;
-// }
-
-void OS::CheckTerminal() { return; }
-
-#endif

--- a/src/OS.h
+++ b/src/OS.h
@@ -5,7 +5,6 @@
 
 namespace OS {
     void LowerThreadPriority();
-    void CheckTerminal();
     const std::filesystem::path GetMusicDirectory();
     const std::filesystem::path GetLocalConfigDirectory();
     const std::filesystem::path GetGlobalConfigDirectory();

--- a/src/PlayerContext.cpp
+++ b/src/PlayerContext.cpp
@@ -39,13 +39,6 @@ void PlayerContext::ProcessMidi()
             // invalid status
             continue;
         }
-        // tempo
-        if (status == 0xFF && message[1] == 0x51) {
-            uint32_t mspt = (message[3] << 16) | (message[4] << 8) | message[5];
-            uint8_t bpm = static_cast<uint8_t>(60000000.0f / mspt / 2.0f);
-            reader.PlayLiveCommand(0xBB, bpm, 0, 0);
-            continue;
-        }
         if (status >= 0xF0) {
             // todo: parse meta / sysex
             continue;
@@ -93,6 +86,9 @@ void PlayerContext::ProcessMidi()
                 continue;
             case 24:    // tune
                 reader.PlayLiveCommand(0xC8, 0, sarg2, channel);
+                continue;
+            case 29:    // emulate tempo (bpm / 2)
+                reader.PlayLiveCommand(0xBB, uarg2, 0, 0);
                 continue;
             case 33:    // priority
                 reader.PlayLiveCommand(0xBA, uarg2, 0, channel);

--- a/src/PlayerContext.h
+++ b/src/PlayerContext.h
@@ -19,6 +19,7 @@ struct PlayerContext {
             RtMidiIn *midiin);
 
     void Process(std::vector<std::vector<sample>>& trackAudio);
+    // TODO pull this out into a separate class
     void ProcessMidi();
     void InitSong(size_t songPos, bool liveMode = false);
     bool HasEnded() const;
@@ -29,6 +30,7 @@ struct PlayerContext {
     Sequence seq;
     SoundBank bnk;
     EnginePars pars;
+    // TODO pull this out into a separate class
     RtMidiIn *midiin;
 
     // sound channels

--- a/src/agbplay.cpp
+++ b/src/agbplay.cpp
@@ -18,8 +18,6 @@ static void help();
 
 int main(int argc, char *argv[]) 
 {
-    OS::CheckTerminal();
-
     if (!Debug::open(nullptr)) {
         std::cout << "Debug Init failed" << std::endl;
         return EXIT_FAILURE;

--- a/src/agbplay.cpp
+++ b/src/agbplay.cpp
@@ -116,6 +116,7 @@ static void help()
         "  - T: Toggle whether the song should be output to a file (see R and E)\n"
         "  - G: Drag the song through the playlist for ordering\n"
         "  - I: Force Song Restart\n"
+        "    - In Live MIDI mode this will simply turn off all notes without resetting controllers.\n"
         "  - O: Song Play/Pause\n"
         "  - P: Force Song Stop\n"
         "  - +=: Double the playback speed\n"


### PR DESCRIPTION
* Add CC 29 for emulating a tempo change command. This is needed to properly set the tick length for things such as modulation delay.
* Properly remove the mac terminal check.
* Update and minor fixes to README.md